### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         draft: false
         prerelease: false
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: squisty/olympic_medal_htest # change this to your DockerHub username and repository
         username: ${{ secrets.DOCKER_USERNAME }} # you need to add your Docker username to this GitHub repo as a secret

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ The local repository can be reset to the initial cloned state by running:
 ```
 make clean
 ```
+### File dependency diagram
+Please see below for our file dependencies:
 
+![Dependency Diagram](Makefile.png)
 
 ## Dependencies
 

--- a/results/04_htest_final_report.Rmd
+++ b/results/04_htest_final_report.Rmd
@@ -54,7 +54,7 @@ We can see from the table above that there are 131,134 athletes under age of 25 
 knitr::include_graphics("../results/04_h0_dist.png")
 ```
 
-After generating the null distribution, and placing our observed test statistic on the plot in figure 1, we can see that the observed test statistics (red line) falls within the significance threshold (blue line), therefore we fail to reject $H_0$.
+After generating the null distribution, and placing our observed test statistic on the plot in figure 5, we can see that the observed test statistics (red line) falls within the significance threshold (blue line), therefore we fail to reject $H_0$.
 
 ```{r p_value result, echo=FALSE}
 kable(p_value, caption = "Table 4. p-value for the test.", col.names = 'p-value') |>


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore